### PR TITLE
Dynamo_Toolkit  - allow arrays as input

### DIFF
--- a/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
+++ b/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
@@ -98,12 +98,14 @@ namespace BH.Engine.Dynamo.Objects
 
         public override List<T> GetDataList<T>(int index)
         {
-            object content = GetInputAt(index);
-            if (content is ListWrapper)
-                content = ((ListWrapper)content).Items;
-            IEnumerable data = content as IEnumerable;
+            return GetDataCollection<T>(index).ToList();
+        }
 
-            return data.Cast<object>().Select(x => x.IToBHoM()).Cast<T>().ToList();
+        /*************************************/
+
+        public override T[] GetDataArray<T>(int index)
+        {
+            return GetDataCollection<T>(index).ToArray();
         }
 
         /*************************************/
@@ -176,5 +178,15 @@ namespace BH.Engine.Dynamo.Objects
         }
 
         /***************************************************/
+
+        private IEnumerable<T> GetDataCollection<T>(int index)
+        {
+            object content = GetInputAt(index);
+            if (content is ListWrapper)
+                content = ((ListWrapper)content).Items;
+            IEnumerable data = content as IEnumerable;
+
+            return data.Cast<object>().Select(x => x.IToBHoM()).Cast<T>();
+        }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on https://github.com/BHoM/BHoM_UI/pull/117
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/Grasshopper_Toolkit/issues/226

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Em-Ac-zHyvNJqLkWV2MSQFoBUv7UtLIpcY0a86KHJ25X7A?e=9FTc7u

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adds `public abstract T[] DataAccessor.GetDataArray<T>(int index);`

### Additional comments
<!-- As required -->
This pr is to support https://github.com/BHoM/Grasshopper_Toolkit/pull/389. It adds an array getter. The method is abstract so, it must be implemented.