### PR TITLE
Fix error when list or tree inputs are null

### DIFF
--- a/Dynamo_Engine/Convert/ToTargetType.cs
+++ b/Dynamo_Engine/Convert/ToTargetType.cs
@@ -46,6 +46,9 @@ namespace BH.Engine.Dynamo
             else if (item is TreeWrapper)
                 item = ((TreeWrapper)item).Items;
 
+            if (item == null)
+                return null;
+
             if (item.GetType() == type)
                 return item;
             else

--- a/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
+++ b/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
@@ -101,6 +101,8 @@ namespace BH.Engine.Dynamo.Objects
             object content = GetInputAt(index);
             if (content is ListWrapper)
                 content = ((ListWrapper)content).Items;
+            if (content == null)
+                content = new List<T>();
             IEnumerable data = content as IEnumerable;
 
             return data.Cast<object>().Select(x => x.IToBHoM()).Cast<T>().ToList();
@@ -113,6 +115,8 @@ namespace BH.Engine.Dynamo.Objects
             object content = GetInputAt(index);
             if (content is TreeWrapper)
                 content = ((TreeWrapper)content).Items;
+            if (content == null)
+                content = new List<List<T>>();
             IEnumerable<IEnumerable> data = content as IEnumerable<IEnumerable>;
 
             return data.Select(y => y.Cast<object>().Select(x => x.IToBHoM()).Cast<T>().ToList()).ToList();


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #90 

### Test files
You can try with this small script:

![image](https://user-images.githubusercontent.com/16853390/65695112-d0771400-e06e-11e9-8620-9e1077061123.png)

Without this PR, the component would turn yellow when you disconnect the reinforcement input. This PR fixes that (i.e. support for null default value on lists and trees)
