### PR TITLE
Fix of the cyclical nurbs curve conversion & support for trimmed surf…

### DIFF
--- a/Dynamo_Engine/Convert/ToBHoM.cs
+++ b/Dynamo_Engine/Convert/ToBHoM.cs
@@ -197,12 +197,16 @@ namespace BH.Engine.Dynamo
             vKnots.RemoveAt(vKnots.Count - 1);
 
             return surface == null ? null : new BHG.NurbsSurface
-            {
-                ControlPoints = surface.ControlPoints().SelectMany(x => x.Select(y => y.ToBHoM())).ToList(),
-                Weights = surface.Weights().SelectMany(x => x).ToList(),
-                UKnots = uKnots,
-                VKnots = vKnots
-            };
+            (
+                surface.ControlPoints().SelectMany(x => x.Select(y => y.ToBHoM())).ToList(),
+                surface.Weights().SelectMany(x => x).ToList(),
+                uKnots,
+                vKnots,
+                surface.DegreeU,
+                surface.DegreeV,
+                new List<BHG.SurfaceTrim>(),
+                new List<BHG.SurfaceTrim>()
+            );
         }
 
         /***************************************************/

--- a/Dynamo_Engine/Convert/ToDesignScript.cs
+++ b/Dynamo_Engine/Convert/ToDesignScript.cs
@@ -179,8 +179,8 @@ namespace BH.Engine.Dynamo
 
             try
             {
-                List<ADG.PolyCurve> trims = surface.ExternalBoundaries3d.Select(x => (x as BHG.PolyCurve).ToDesignScript()).ToList();
-                trims.AddRange(surface.InternalBoundaries3d.Select(x => (x as BHG.PolyCurve).ToDesignScript()).ToList());
+                List<ADG.PolyCurve> trims = surface.OuterTrims.Select(x => (x.Curve3d as BHG.PolyCurve).ToDesignScript()).ToList();
+                trims.AddRange(surface.InnerTrims.Select(x => (x.Curve3d as BHG.PolyCurve).ToDesignScript()).ToList());
                 ADGSurface = ADGSurface.TrimWithEdgeLoops(trims);
             }
             catch


### PR DESCRIPTION
### NOTE: Depends on 
[#603](https://github.com/BHoM/BHoM/pull/603)
[#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
[#435](https://github.com/BHoM/Revit_Toolkit/pull/435)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #181 
Closes #182

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test files are located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
- [#122](https://github.com/BHoM/Rhinoceros_Toolkit/pull/122)
- [#435](https://github.com/BHoM/Grasshopper_Toolkit/pull/435)
- [#435](https://github.com/BHoM/Revit_Toolkit/pull/435)
- [#183](https://github.com/BHoM/Dynamo_Toolkit/pull/183)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `NurbsCurve` conversion to DesignScript has been fixed to accept knot vectors not starting with 0
- `NurbsSurface` conversion was extended to attempt to add trims

### Additional comments
Please see [#603](https://github.com/BHoM/BHoM/pull/603).
This PR allows pushing trimmed surfaces. It works correctly only for a limited range of cases: it seems that there is no way to construct a trimmed surface from scratch, while `Surface.TrimWithEdgeLoops()` does not work any better than most of Dynamo 🐒 

Issues to be raised after this gets merged:
- add pull support for trimmed surfaces
- add ToBHoM and ToDesignScript converts for `PlanarSurface`
- add ToBHoM and ToDesignScript converts for `BoundaryRepresentation`
- add ToBHoM and ToDesignScript converts for primitives (`Sphere`, `Cone` etc.)
- Dynamo suppresses warnings recorded by the BHoM methods (`ClearCurrentEvents()` called by `RunCaller` method does it?)