### PR TITLE
Expose BHoM warnings to the UI

### DIFF
--- a/Dynamo_UI/Templates/CallerComponent.cs
+++ b/Dynamo_UI/Templates/CallerComponent.cs
@@ -63,6 +63,7 @@ namespace BH.UI.Dynamo.Templates
             Caller.SetDataAccessor(new DataAccessor_Dynamo());
             Caller.ItemSelected += (sender, e) => RefreshComponent();
             BH.Engine.Dynamo.Compute.Callers[InstanceID.ToString()] = Caller;
+            BH.Engine.Dynamo.Compute.Nodes[InstanceID.ToString()] = this;
 
             RefreshComponent();
         }

--- a/Dynamo_UI/Templates/CallerValueList.cs
+++ b/Dynamo_UI/Templates/CallerValueList.cs
@@ -64,6 +64,7 @@ namespace BH.UI.Dynamo.Templates
 
             Caller.SetDataAccessor(new DataAccessor_Dynamo());
             BH.Engine.Dynamo.Compute.Callers[InstanceID.ToString()] = Caller;
+            BH.Engine.Dynamo.Compute.Nodes[InstanceID.ToString()] = this;
 
             AddPort(PortType.Output, Caller.OutputParams.First().ToPortData(), 0);
 


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #185

<!-- Add short description of what has been fixed -->


### Test files
![image](https://user-images.githubusercontent.com/16853390/72126610-b8ba6600-33a7-11ea-8bcc-5ab4ecc30a65.png)

![image](https://user-images.githubusercontent.com/16853390/72126621-c53ebe80-33a7-11ea-9b9a-0ca5f45fae5b.png)


`GetProperty` is throwing a warning while `Explode` is throwing an error in this specific script.


### Additional comments
- This is annoying that errors are not appearing in red instead of yellow. But I am not sure there is anything we can do about this since I am already throwing an exception for errors.
- The way I show the warnings is a bit hacky. The proper way would probably be to somehow send notifications to the views and have them handle the errors/warning message there. But, in all honesty, I don't want to wrestle with Dynamo for hours/days in order to find a way to do that.  
- Along the same line, I have to force the warning to show by using persistent warnings (the `true` argument when calling `Warning` in line 183) as nothing is ever showing otherwise. This is why I am then forced to manually clear `persistentWarning` through reflection has there is no interface to do that.
- @FraserGreenroyd , I don't really know who else I can add as a reviewer for Dynamo now that Michael and Jakub are gone so I have nominated you. Feel free to offer an alternative.
