### PR TITLE
Upgrade to Dynamo 2.0.1

### DIFF
--- a/Dynamo_Engine/Compute/RunCaller.cs
+++ b/Dynamo_Engine/Compute/RunCaller.cs
@@ -201,7 +201,7 @@ namespace BH.Engine.Dynamo
                 FieldInfo field = typeof(NodeModel).GetField("persistentWarning", BindingFlags.NonPublic | BindingFlags.Instance);
                 if (field != null)
                     field.SetValue(node, "");
-                node.ClearRuntimeError();
+                node.ToolTipText = "";
             }
         }
 

--- a/Dynamo_Engine/Convert/ToDesignScript.cs
+++ b/Dynamo_Engine/Convert/ToDesignScript.cs
@@ -71,6 +71,18 @@ namespace BH.Engine.Dynamo
 
         /***************************************************/
 
+        public static ADG.CoordinateSystem ToDesignScript(this BHG.Basis basis)
+        {
+            return ADG.CoordinateSystem.ByOriginVectors(
+                ADG.Point.ByCoordinates(0,0,0),
+                basis.X.ToDesignScript(),
+                basis.Y.ToDesignScript(),
+                basis.Z.ToDesignScript()
+            );
+        }
+
+        /***************************************************/
+
         public static ADG.Arc ToDesignScript(this BHG.Arc arc)
         {
             return ADG.Arc.ByThreePoints(arc.StartPoint().ToDesignScript(), arc.PointAtParameter(0.5).ToDesignScript(), arc.EndPoint().ToDesignScript());

--- a/Dynamo_Engine/Dynamo_Engine.csproj
+++ b/Dynamo_Engine/Dynamo_Engine.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.Dynamo</RootNamespace>
     <AssemblyName>Dynamo_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,24 +42,40 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_UI\Build\BHoM_UI.dll</HintPath>
     </Reference>
-    <Reference Include="DynamoCore, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\DynamoCore.dll</HintPath>
+    <Reference Include="DesignScriptBuiltin, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DesignScriptBuiltin.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoServices, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.1.2.0\lib\net45\DynamoServices.dll</HintPath>
+    <Reference Include="DSIronPython, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DSIronPython.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoShapeManager, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\DynamoShapeManager.dll</HintPath>
+    <Reference Include="DynamoApplications, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DynamoApplications.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoUnits, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.2.0\lib\net45\DynamoUnits.dll</HintPath>
+    <Reference Include="DynamoCore, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoUtilities, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\DynamoUtilities.dll</HintPath>
+    <Reference Include="DynamoInstallDetective, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DynamoInstallDetective.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoServices, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.2.0.1.5055\lib\net45\DynamoServices.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoShapeManager, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DynamoShapeManager.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoUnits, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.1.5055\lib\net45\DynamoUnits.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoUtilities, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\DynamoUtilities.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
@@ -83,16 +100,20 @@
       <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoCore, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\ProtoCore.dll</HintPath>
+    <Reference Include="ProtoCore, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoGeometry">
-      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.2.0\lib\net45\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.1.5055\lib\net45\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
@@ -120,6 +141,9 @@
     </Reference>
     <Reference Include="UI_oM">
       <HintPath>..\..\BHoM_UI\Build\UI_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="VMDataBridge, Version=2.0.1.5055, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.1.5055\lib\net45\VMDataBridge.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Dynamo_Engine/packages.config
+++ b/Dynamo_Engine/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.0" targetFramework="net452" />
-  <package id="DynamoVisualProgramming.Core" version="1.2.0" targetFramework="net452" />
-  <package id="DynamoVisualProgramming.DynamoServices" version="1.2.0" targetFramework="net452" />
-  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.2.0" targetFramework="net452" />
+  <package id="DynamoVisualProgramming.Core" version="2.0.1.5055" targetFramework="net47" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="2.0.1.5055" targetFramework="net47" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="2.0.1.5055" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net47" />
   <package id="NUnit" version="2.6.3" targetFramework="net452" />
   <package id="Prism" version="4.1.0.0" targetFramework="net452" />
 </packages>

--- a/Dynamo_UI/Components/Adapter/CreateAdapter.cs
+++ b/Dynamo_UI/Components/Adapter/CreateAdapter.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new CreateAdapterCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateAdapterComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateAdapterComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/CreateRequest.cs
+++ b/Dynamo_UI/Components/Adapter/CreateRequest.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new CreateRequestCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateRequestComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateRequestComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/Delete.cs
+++ b/Dynamo_UI/Components/Adapter/Delete.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new RemoveCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public DeleteComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public DeleteComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/Execute.cs
+++ b/Dynamo_UI/Components/Adapter/Execute.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new ExecuteCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ExecuteComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public ExecuteComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/Move.cs
+++ b/Dynamo_UI/Components/Adapter/Move.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new MoveCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public MoveComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public MoveComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/Pull.cs
+++ b/Dynamo_UI/Components/Adapter/Pull.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,16 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new PullCaller();
 
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public PullComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public PullComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/Push.cs
+++ b/Dynamo_UI/Components/Adapter/Push.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new PushCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public PushComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public PushComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Adapter/Remove.cs
+++ b/Dynamo_UI/Components/Adapter/Remove.cs
@@ -48,12 +48,12 @@ namespace BH.UI.Dynamo.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public DeleteComponent() : base() { }
+        public RemoveComponent() : base() { }
 
         /*******************************************/
 
         [JsonConstructor]
-        public DeleteComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+        public RemoveComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/Compute.cs
+++ b/Dynamo_UI/Components/Engine/Compute.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new ComputeCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ComputeComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public ComputeComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/Convert.cs
+++ b/Dynamo_UI/Components/Engine/Convert.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new ConvertCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ConvertComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public ConvertComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/Explode.cs
+++ b/Dynamo_UI/Components/Engine/Explode.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Dynamo.Graph;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -46,6 +47,18 @@ namespace BH.UI.Dynamo.Components
         /*******************************************/
 
         public override Caller Caller { get; } = new ExplodeCaller();
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ExplodeComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public ExplodeComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
 
         /*******************************************/

--- a/Dynamo_UI/Components/Engine/FromJson.cs
+++ b/Dynamo_UI/Components/Engine/FromJson.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new FromJsonCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public FromJsonComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public FromJsonComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/GetInfo.cs
+++ b/Dynamo_UI/Components/Engine/GetInfo.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new GetInfoCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public GetInfoComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public GetInfoComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/GetProperty.cs
+++ b/Dynamo_UI/Components/Engine/GetProperty.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new GetPropertyCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public GetPropertyComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public GetPropertyComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/Modify.cs
+++ b/Dynamo_UI/Components/Engine/Modify.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new ModifyCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ModifyComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public ModifyComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/Query.cs
+++ b/Dynamo_UI/Components/Engine/Query.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new QueryCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public QueryComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public QueryComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/SetProperty.cs
+++ b/Dynamo_UI/Components/Engine/SetProperty.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new SetPropertyCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public SetPropertyComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public SetPropertyComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/Engine/ToJson.cs
+++ b/Dynamo_UI/Components/Engine/ToJson.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -43,6 +44,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new ToJsonCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ToJsonComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public ToJsonComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/oM/CreateCustom.cs
+++ b/Dynamo_UI/Components/oM/CreateCustom.cs
@@ -30,6 +30,7 @@ using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -45,6 +46,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new CreateCustomCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateCustomComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateCustomComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/oM/CreateData.cs
+++ b/Dynamo_UI/Components/oM/CreateData.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override MultiChoiceCaller Caller { get; } = new CreateDataCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateDataComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateDataComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/oM/CreateDictionary.cs
+++ b/Dynamo_UI/Components/oM/CreateDictionary.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new CreateDictionaryCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateDictionaryComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateDictionaryComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/oM/CreateEnum.cs
+++ b/Dynamo_UI/Components/oM/CreateEnum.cs
@@ -28,6 +28,7 @@ using CoreNodeModels;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -43,6 +44,17 @@ namespace BH.UI.Dynamo.Components
 
         public override MultiChoiceCaller Caller { get; } = new CreateEnumCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateEnumComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateEnumComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
         /*******************************************/
     }

--- a/Dynamo_UI/Components/oM/CreateObject.cs
+++ b/Dynamo_UI/Components/oM/CreateObject.cs
@@ -31,6 +31,7 @@ using System;
 using BH.oM.UI;
 using BH.Engine.Dynamo;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -66,11 +67,11 @@ namespace BH.UI.Dynamo.Components
         private void Caller_InputToggled(object sender, Tuple<ParamInfo, bool> e)
         {
             if (e.Item2)
-                AddPort(PortType.Input, e.Item1.ToPortData(), InPorts.Count);
+                InPorts.Add(new PortModel(PortType.Input, this, e.Item1.ToPortData()));
             else
             {
                 string name = e.Item1.Name.ToLower();
-                int index = InPorts.ToList().FindIndex(x => x.PortName.ToLower() == name);
+                int index = InPorts.ToList().FindIndex(x => x.Name.ToLower() == name);
                 if (index >= 0)
                     InPorts.RemoveAt(index);
             }

--- a/Dynamo_UI/Components/oM/CreateType.cs
+++ b/Dynamo_UI/Components/oM/CreateType.cs
@@ -27,6 +27,7 @@ using BH.UI.Templates;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace BH.UI.Dynamo.Components
 {
@@ -42,6 +43,17 @@ namespace BH.UI.Dynamo.Components
 
         public override Caller Caller { get; } = new CreateTypeCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateTypeComponent() : base() {}
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public CreateTypeComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) {}
 
         /*******************************************/
     }

--- a/Dynamo_UI/Dynamo_UI.csproj
+++ b/Dynamo_UI/Dynamo_UI.csproj
@@ -203,7 +203,7 @@
     <Compile Include="Components\Adapter\Pull.cs" />
     <Compile Include="Components\Adapter\Move.cs" />
     <Compile Include="Components\Adapter\Execute.cs" />
-    <Compile Include="Components\Adapter\Delete.cs" />
+    <Compile Include="Components\Adapter\Remove.cs" />
     <Compile Include="Components\Engine\Explode.cs" />
     <Compile Include="Components\Engine\GetInfo.cs" />
     <Compile Include="Components\Engine\Query.cs" />

--- a/Dynamo_UI/Dynamo_UI.csproj
+++ b/Dynamo_UI/Dynamo_UI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.UI.Dynamo</RootNamespace>
     <AssemblyName>Dynamo_UI</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -64,28 +64,44 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>
     </Reference>
-    <Reference Include="DynamoCore, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\DynamoCore.dll</HintPath>
+    <Reference Include="DesignScriptBuiltin, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DesignScriptBuiltin.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DSIronPython, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DSIronPython.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoApplications, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DynamoApplications.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoCore, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCoreWpf, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.2.0\lib\net45\DynamoCoreWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoServices, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.1.2.0\lib\net45\DynamoServices.dll</HintPath>
+    <Reference Include="DynamoInstallDetective, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DynamoInstallDetective.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoShapeManager, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\DynamoShapeManager.dll</HintPath>
+    <Reference Include="DynamoServices, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.2.3.0.5885\lib\net47\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoUnits, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.2.0\lib\net45\DynamoUnits.dll</HintPath>
+    <Reference Include="DynamoShapeManager, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DynamoShapeManager.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoUtilities, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\DynamoUtilities.dll</HintPath>
+    <Reference Include="DynamoUnits, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.3.0.5885\lib\net47\DynamoUnits.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoUtilities, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\DynamoUtilities.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
@@ -111,18 +127,22 @@
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.Interactivity.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoCore, Version=1.2.0.2690, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DynamoVisualProgramming.Core.1.2.0\lib\net45\ProtoCore.dll</HintPath>
+    <Reference Include="ProtoCore, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoGeometry">
-      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.2.0\lib\net45\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.3.0.5132, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.3.0.5885\lib\net47\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
@@ -170,6 +190,9 @@
     </Reference>
     <Reference Include="UI_PostBuild">
       <HintPath>..\..\BHoM_UI\Build\UI_PostBuild.exe</HintPath>
+    </Reference>
+    <Reference Include="VMDataBridge, Version=2.3.0.5885, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.3.0.5885\lib\net47\VMDataBridge.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -240,7 +263,19 @@
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\pkg.json"
 
 call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
-Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\pkg.json"</PostBuildEvent>
+Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\pkg.json"
+
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
+Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\pkg.json"
+
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
+Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\pkg.json"
+
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
+Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\pkg.json"
+
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
+Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\pkg.json"</PostBuildEvent>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Revit\1.3\DynamoSandbox.exe</StartProgram>
   </PropertyGroup>

--- a/Dynamo_UI/Views/oM/CreateCustom.cs
+++ b/Dynamo_UI/Views/oM/CreateCustom.cs
@@ -32,6 +32,7 @@ using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using Dynamo.ViewModels;
 
 namespace BH.UI.Dynamo.Views
 {
@@ -97,7 +98,7 @@ namespace BH.UI.Dynamo.Views
         private void AddButton_Click(object sender, RoutedEventArgs e)
         {
             CreateCustomCaller caller = m_Node.Caller as CreateCustomCaller;
-            List<string> inputs = m_Node.InPorts.Select(x => x.PortName).ToList();
+            List<string> inputs = m_Node.InPorts.Select(x => x.Name).ToList();
             
             var button = new DynamoNodeButton() { Content = "-", Width = 26, Height = 26 };
             button.Click += RemoveButton_Click;
@@ -119,7 +120,7 @@ namespace BH.UI.Dynamo.Views
             m_ButtonPanel.Children.Remove(button);
 
             CreateCustomCaller caller = m_Node.Caller as CreateCustomCaller;
-            List<string> inputs = m_Node.InPorts.Select(x => x.PortName).ToList();
+            List<string> inputs = m_Node.InPorts.Select(x => x.Name).ToList();
             inputs.RemoveAt(index);
             caller.SetInputs(inputs);
             m_Node.RefreshComponent();
@@ -143,7 +144,7 @@ namespace BH.UI.Dynamo.Views
 
             for (int i = m_InputNameItems.Count; i < m_Node.InPorts.Count; i++)
             {
-                TextBox textBox = new TextBox { Text = m_Node.InPorts[i].PortName };
+                TextBox textBox = new TextBox { Text = m_Node.InPorts[i].Name };
                 textBox.TextChanged += TextBox_TextChanged;
                 m_Menu.Items.Add(textBox);
                 m_InputNameItems.Add(textBox);
@@ -168,6 +169,10 @@ namespace BH.UI.Dynamo.Views
                 List<string> inputs = m_InputNameItems.Select(x => x.Text).ToList();
                 caller.SetInputs(inputs);
                 m_Node.RefreshComponent();
+
+                MethodInfo method = typeof(Microsoft.Practices.Prism.ViewModel.NotificationObject).GetMethod("RaisePropertyChanged", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(string) }, null);
+                foreach(PortViewModel port in m_View.ViewModel.InPorts)
+                    method.Invoke(port, new object[] { "PortName" });
             }
         }
 

--- a/Dynamo_UI/Views/oM/CreateObject.cs
+++ b/Dynamo_UI/Views/oM/CreateObject.cs
@@ -114,7 +114,7 @@ namespace BH.UI.Dynamo.Views
             m_ButtonPanel.Children.Remove(button);
 
             CreateObjectCaller caller = m_Node.Caller as CreateObjectCaller;
-            List<string> inputs = m_Node.InPorts.Select(x => x.PortName).ToList();
+            List<string> inputs = m_Node.InPorts.Select(x => x.Name).ToList();
             caller.RemoveInput(inputs[index]);
             inputs.RemoveAt(index);
             m_Node.RefreshComponent();

--- a/Dynamo_UI/app.config
+++ b/Dynamo_UI/app.config
@@ -12,4 +12,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/Dynamo_UI/packages.config
+++ b/Dynamo_UI/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.Core" version="1.2.0" targetFramework="net452" />
-  <package id="DynamoVisualProgramming.DynamoServices" version="1.2.0" targetFramework="net452" />
+  <package id="DynamoVisualProgramming.Core" version="2.3.0.5885" targetFramework="net47" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="2.3.0.5885" targetFramework="net47" />
   <package id="DynamoVisualProgramming.WpfUILibrary" version="1.2.0" targetFramework="net452" />
-  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.2.0" targetFramework="net452" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="2.3.0.5885" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net47" />
   <package id="NUnit" version="2.6.3" targetFramework="net452" />
   <package id="Prism" version="4.1.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #139

The changes required for the upgrade are significant enough that I though better to do a first commit on top of the original code. The idea is for you to be able to clearly see the changes I have made as a diffing. Obviously, we will want to keep compatibility with both versions so I will work on that tomorrow (more about it later).

Here are the changes made:
- **_Linking to the new Dynamo NuGets and dlls_**. VERY important to make sure that hose dlls are not copied over (set copy local to false) as this creates a lot of weird behaviours and was preventing BHoM to work in sandbox mode.
- **_Rename `PortName` and `NickName` properties to `Name`_**. The first one being a property of `PortModel` and the second a property of the component itself. 
- **_Adding the `SerialisedCaller` property to `CallerComponent` and `CallerValueList`_**. Dynamo is now using Json instead of Xml to save to components. They DO NOT (I repeat, DO NOT) provide a virtual method that you can override to save additional stuff. Since all public properties are now automatically serialised when saving the component, I created a fake property that contains the stuff I need to save.
- **_Tag `Caller` property with `[JsonIgnore]`_**. The serialisation of the Caller Property was causing an infinite loop that was freezing Dynamo a few seconds after starting it. So I made sure it was ignored.
- **_Add a `[JsonConstructor]' EVERYWHERE_**. The idea here is that the constructor needs to behave differently when a component is created by the user and when it is created by deserialisation. Basically, All the input and output ports are added outside the constructor by Dynamo on the second case but not on the first. The problem is you have no way of knowing from within the constructor so Autodesk solution was to ask you to add a second constructor with that fancy attribute.  Fun fact: this only works on the constructors found in the class itself, not the constructors from the parent classes so you have to make sure it added to all component classes you create.
- **_Keep `(De)SerializeCore` methods_**. This is actually not a change but I thought it was important to mention it. Those two methods are marked as deprecated BUT Dynamo actually needs them for copy/paste. Remember the whole json serialisation? Yep, well, it's not actually used when copy-paste, only for saving/opening files. For that, the only option is still those now deprecated methods.
- **_Getting rid of the `AddPort` and `SetPortData` methods_**. That one is a really good thing. We are finally rid of the weird duplication of data between `PortModel` and `PortData`. Note that the lists of input and output ports are now observable. This means that simply changing those collections will trigger the required updates elsewhere. So the changes required for the updates where mainly nice and clean.... mainly.
- **_Doing some funky reflection when needing to modify properties of the ports_**. Except for the tooltip property, all the rest is read only with private setters. So simple things like updating an input name has gone from trivial to painful. Thank god for reflection.
- **_Forcing the view for the input ports to update when their name was changed_**. Somehow, they have decided that ports would never be modified in a way that required their view to be updated. With some hacking through reflection, I therefore force the triggering of the corresponding WPF component so its data binding would kick in.
- **_Removing the `ValidateConnections` method from `CallerComponent.RefreshComponent()`_**. That method doesn't exist anymore.
- **_Minor changes on the Engine side_**: The engine can actually be kept compatible with  both versions (except for the dll references obviously). The changes there are just a generic alternative to the removed `ClearRuntimeError` method and the addition of support for `Geometry.Basis' that was needed anyway but was crashing the Explode component when I was testing.

### Test files
<!-- Link to test files to validate the proposed changes -->
![image](https://user-images.githubusercontent.com/16853390/72508333-777ef600-3880-11ea-93b3-ac51c110b066.png)

All components were still working after copy/paste and reopening the file

### Additional comments
I'll put my notes on the handling of 1.3 vs 2.0 on a separate comment since this is getting quite big