### PR TITLE
Dynamo 2.0: Fix CustomData Explode

### DIFF
--- a/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
+++ b/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
@@ -42,10 +42,7 @@ namespace BH.Engine.Dynamo
 
         public static object IFromDesignScript(this object obj)
         {
-            if (obj is IEnumerable || obj is ADG.Geometry || obj is ADG.Vector)
-                return Convert.FromDesignScript(obj as dynamic);
-            else
-                return obj;
+            return Convert.FromDesignScript(obj as dynamic);
         }
 
         /***************************************************/
@@ -73,6 +70,18 @@ namespace BH.Engine.Dynamo
             }
         }
 
+
+        /***************************************************/
+
+        public static Dictionary<string, object> FromDesignScript(this DesignScript.Builtin.Dictionary dic)
+        {
+            Dictionary<string, object> result = new Dictionary<string, object>();
+            foreach (string key in dic.Keys)
+                result[key] = dic.ValueAtKey(key);
+
+            return result;
+        }
+
         /***************************************************/
 
         // Issue with natvie Dynamo nodes to be confused (Issue 83)
@@ -80,6 +89,16 @@ namespace BH.Engine.Dynamo
         //{
         //    return list.ToArray().Select(x => x.IFromDesignScript()).ToList();
         //}
+
+
+        /***************************************************/
+        /**** Public Methods  - Fallback                ****/
+        /***************************************************/
+
+        public static object FromDesignScript(this object obj)
+        {
+            return obj;
+        }
 
         /***************************************************/
         /**** Public Methods  - Geometry                ****/

--- a/Dynamo20/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
+++ b/Dynamo20/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
@@ -58,11 +58,11 @@ namespace BH.Engine.Dynamo.Objects
 
             Type aType = aObject.GetType();
 
+            if (aType.Namespace.StartsWith("Autodesk.DesignScript") || aType.Namespace.StartsWith("DesignScript.Builtin"))
+                return (T)(aObject.IFromDesignScript());
+
             if (aType == typeof(T) || typeof(T).IsAssignableFrom(aType))
                 return (T)aObject;
-
-            if (aType.Namespace.StartsWith("Autodesk.DesignScript"))
-                return (T)(aObject.IFromDesignScript());
 
             if (typeof(T) == typeof(double))
             {

--- a/Dynamo20/Dynamo_UI/Views/Engine/Explode.cs
+++ b/Dynamo20/Dynamo_UI/Views/Engine/Explode.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using BH.Engine.Dynamo;
 
 namespace BH.UI.Dynamo.Views
 {
@@ -102,7 +103,7 @@ namespace BH.UI.Dynamo.Views
                     return new List<object>();
             }
             else
-                return new List<object> { mirrorData.Data };
+                return new List<object> { mirrorData.Data.IFromDesignScript() };
         }
 
         /*******************************************/


### PR DESCRIPTION
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #225 

I didn't have the same exact problem as in the issue but that might be because I am fixing for Dynamo 2.0. The problem was that Dynamo is using its own proprietary Dictionary class instead of the standard System dictionary. So instead of having the content exploded, I had `Keys` and `Values`. This PR fixes that by handling the conversion on inputs:

### Test files
![image](https://user-images.githubusercontent.com/16853390/81645137-9c186280-945b-11ea-8519-381b4b7f604f.png)


### Additional comments
- It is worth noting that I had a lot of problems using Dynamo at all (cannot create components, reopened file were failing,..) until I cleaned my build folders and recompiled everything. I did that using code assistant (with a few changes that I will PR soon) but you can also do that manually or use PowerShell scripts (@al-fisher has some apparently).
- Based on the image Kayleigh posted on the issue, I guess that she was using Dynamo 1.3 and that 1.3 is using lists instead of dictionaries. In that case, there is nothing to explode since it's already a list and needs regular Dynamo tools to process the data. 