### PR TITLE
Remove dependency to UI_PostBuild

### DIFF
--- a/Dynamo13/Dynamo_UI/Dynamo13_UI.csproj
+++ b/Dynamo13/Dynamo_UI/Dynamo13_UI.csproj
@@ -246,15 +246,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "..\..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\bin"
+    <PostBuildEvent>xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\bin"
-
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\pkg.json"
 
-
-
-call "..\..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
-
+xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\pkg.json"</PostBuildEvent>
     <StartAction>Program</StartAction>

--- a/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
+++ b/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
@@ -269,19 +269,19 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "..\..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
+    <PostBuildEvent>xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\pkg.json"
 
-call "..\..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
+xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\pkg.json"
 
-call "..\..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
+xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\pkg.json"
 
-call "..\..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\..\ "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
+xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\pkg.json"</PostBuildEvent>
     <StartAction>Program</StartAction>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #237 

Ideally I would have liked to completely eliminate the need to copy the dlls to the Dynamo roaming folders but I couldn't find a simple way to do that:
- Adding `ProgramData/BHoM` to the PATH variable is only working if the installer was ran at least once. Moreover that would create issues for multiple users since we cannot edit the system path.
- Dynamo packages don't have a clear entry point so we cannot just dynamically resolve path using `AppDomain.CurrentDomain.AssemblyResolve`

So simply copy all the dlls from `ProgramData/BhoM` for now

