### PR TITLE
Modify DynamoSettings.xml at build to point to ProgramData/BHoM

### DIFF
--- a/Dynamo13/Dynamo_UI/Dynamo13_UI.csproj
+++ b/Dynamo13/Dynamo_UI/Dynamo13_UI.csproj
@@ -246,12 +246,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\bin"
-xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\bin"
+    <PostBuildEvent>powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File ..\..\postBuild.ps1 "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\DynamoSettings.xml"
+xcopy /Y /E /I ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\1.3\packages\BHoM\pkg.json"
 
-xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
-xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
+powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File ..\..\postBuild.ps1 "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\DynamoSettings.xml"
+xcopy /Y /E /I ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\BHoM\pkg.json"</PostBuildEvent>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Revit\1.3\DynamoSandbox.exe</StartProgram>

--- a/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
+++ b/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
@@ -269,20 +269,20 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
-xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
+    <PostBuildEvent>powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File ..\..\postBuild.ps1 "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\DynamoSettings.xml"
+xcopy /Y /E /I ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\pkg.json"
 
-xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
-xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
+powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File ..\..\postBuild.ps1 "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\DynamoSettings.xml"
+xcopy /Y /E /I ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\pkg.json"
 
-xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
-xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
+powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File ..\..\postBuild.ps1 "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\DynamoSettings.xml"
+xcopy /Y /E /I ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\pkg.json"
 
-xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
-xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
+powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File ..\..\postBuild.ps1 "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\DynamoSettings.xml"
+xcopy /Y /E /I ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\pkg.json"</PostBuildEvent>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Revit\1.3\DynamoSandbox.exe</StartProgram>

--- a/postBuild.ps1
+++ b/postBuild.ps1
@@ -1,0 +1,19 @@
+try {
+	$targetFile = $args[0]
+
+	$doc = [xml](Get-content $targetFile)
+
+	$exists = $doc.PreferenceSettings.CustomPackageFolders.InnerText -like "*C:\ProgramData\BHoM\Assemblies*"
+
+	if (-Not $exists)
+	{
+		$e = $doc.CreateNode("element", "string", "")
+		$e.InnerText = "C:\ProgramData\BHoM\Assemblies"
+		
+		$doc.PreferenceSettings.CustomPackageFolders.AppendChild($e)
+		$doc.save($targetFile)
+	}
+}
+catch {
+	exit 1
+}


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #239

Now only copy the Dynamo toolkit specific dlls to Roaming and modifies `DynamoSettings.xml` to inlcude `ProgramData/BHoM` in the list of custom package folders.

### Test files
After cleaning ALL your BHoM folders inside `Dynamo/Roaming`, and recompiling, make sure BHoM still works in Dynamo for all versions of core and revit. 

