### PR TITLE
Default lacing changed from Shortest to Auto

### DIFF
--- a/Dynamo20/Dynamo_UI/Templates/CallerComponent.cs
+++ b/Dynamo20/Dynamo_UI/Templates/CallerComponent.cs
@@ -68,7 +68,7 @@ namespace BH.UI.Dynamo.Templates
         public CallerComponent() : base()
         {
             Category = "BHoM." + Caller.Category;
-            ArgumentLacing = LacingStrategy.Shortest;
+            ArgumentLacing = LacingStrategy.Auto;
 
             Caller.SetDataAccessor(new DataAccessor_Dynamo());
             Caller.ItemSelected += (sender, e) => RefreshComponent();
@@ -84,7 +84,7 @@ namespace BH.UI.Dynamo.Templates
         public CallerComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             Category = "BHoM." + Caller.Category;
-            ArgumentLacing = LacingStrategy.Shortest;
+            ArgumentLacing = LacingStrategy.Auto;
 
             Caller.SetDataAccessor(new DataAccessor_Dynamo());
             Caller.ItemSelected += (sender, e) => RefreshComponent();

--- a/Dynamo20/Dynamo_UI/Templates/CallerValueList.cs
+++ b/Dynamo20/Dynamo_UI/Templates/CallerValueList.cs
@@ -69,7 +69,7 @@ namespace BH.UI.Dynamo.Templates
         public CallerValueList() : base()
         {
             Category = "BHoM." + Caller.Category;
-            ArgumentLacing = LacingStrategy.Shortest;
+            ArgumentLacing = LacingStrategy.Auto;
 
             Caller.SetDataAccessor(new DataAccessor_Dynamo());
             BH.Engine.Dynamo.Compute.Callers[InstanceID.ToString()] = Caller;
@@ -86,7 +86,7 @@ namespace BH.UI.Dynamo.Templates
         public CallerValueList(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             Category = "BHoM." + Caller.Category;
-            ArgumentLacing = LacingStrategy.Shortest;
+            ArgumentLacing = LacingStrategy.Auto;
 
             Caller.SetDataAccessor(new DataAccessor_Dynamo());
             BH.Engine.Dynamo.Compute.Callers[InstanceID.ToString()] = Caller;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #228

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed - just open Dynamo 2.X and place a standard component, its default lacing is set to Auto. BHoM components should do same (to manipulate lacing right click on the component and go to lacing in the context menu).

![image](https://user-images.githubusercontent.com/26874773/85399498-3689bc80-b557-11ea-90a0-188737ff1bad.png)
