### PR TITLE
Geometry convert fixes

### DIFF
--- a/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
+++ b/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
@@ -204,9 +204,19 @@ namespace BH.Engine.Dynamo
 
         /***************************************************/
 
-        public static BHG.PolyCurve FromDesignScript(this ADG.PolyCurve polyCurve)
+        public static BHG.ICurve FromDesignScript(this ADG.PolyCurve polyCurve)
         {
-            return Geometry.Create.PolyCurve(polyCurve.Curves().Select(x => x.IFromDesignScript()));
+            List<BHG.ICurve> curves = polyCurve.Curves().Select(x => x.IFromDesignScript()).ToList();
+
+            // Force convert to BH.oM.Geometry.Polyline if the curve consists of linear segments only.
+            if (curves.Count != 0 && curves.All(x => x is BHG.Line))
+            {
+                List<BHG.Point> controlPoints = new List<BHG.Point> { ((BHG.Line)curves[0]).Start };
+                controlPoints.AddRange(curves.Select(x => ((BHG.Line)x).End));
+                return new BHG.Polyline { ControlPoints = controlPoints };
+            }
+            else
+                return Geometry.Create.PolyCurve(polyCurve.Curves().Select(x => x.IFromDesignScript()));
         }
 
         /***************************************************/

--- a/Dynamo20/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
+++ b/Dynamo20/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Dynamo.Objects
 
             Type aType = aObject.GetType();
 
-            if (aType.Namespace.StartsWith("Autodesk.DesignScript") || aType.Namespace.StartsWith("DesignScript.Builtin"))
+            if (typeof(T).Namespace.StartsWith("BH.oM") && (aType.Namespace.StartsWith("Autodesk.DesignScript") || aType.Namespace.StartsWith("DesignScript.Builtin")))
                 return (T)(aObject.IFromDesignScript());
 
             if (aType == typeof(T) || typeof(T).IsAssignableFrom(aType))

--- a/Dynamo20/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
+++ b/Dynamo20/Dynamo_Engine/Objects/DataAccessor_Dynamo.cs
@@ -59,7 +59,7 @@ namespace BH.Engine.Dynamo.Objects
             Type aType = aObject.GetType();
 
             if (typeof(T).Namespace.StartsWith("BH.oM") && (aType.Namespace.StartsWith("Autodesk.DesignScript") || aType.Namespace.StartsWith("DesignScript.Builtin")))
-                return (T)(aObject.IFromDesignScript());
+                return (T)(aObject.IFromDesignScript() as dynamic);
 
             if (aType == typeof(T) || typeof(T).IsAssignableFrom(aType))
                 return (T)aObject;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #195 
Closes #196
Closes #227 
Closes #230

Also covers some parts of #224, but this needs further work.
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#195 #196](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FDynamo%5FToolkit%2FDynamo%5FToolkit%2DIssue195%2DPolylineConversionBug)
[#227](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FDynamo%5FToolkit%2FDynamo%5FToolkit%2DIssue227%2DSurfaceConvert)
[#230](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FDynamo%5FToolkit%2FDynamo%5FToolkit%2DIssue230%2DTwoVertexCurve)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Conversion between Dynamo `Polycurve` and BHoM `Polyline` has been unlocked
- Conversion between Dynamo two-node `Curve` and `BHoM` Line has been unlocked
- Conversion of Dynamo `Surface` to BHoM has been fixed to avoid stack overflow

