### PR TITLE
Geometry converts revisited and bugfixed

### DIFF
--- a/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
+++ b/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
@@ -163,7 +163,7 @@ namespace BH.Engine.Dynamo
             if (curve.GetType() == typeof(ADG.Curve))
             {
                 List<ADG.Curve> curves = curve.Explode().Cast<ADG.Curve>().ToList();
-                if (curves.Count != 0)
+                if (curves.Count == 1)
                     return curves[0].IFromDesignScript();
                 else
                     return new BHG.PolyCurve { Curves = curves.Select(x => x.IFromDesignScript()).ToList() };

--- a/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
+++ b/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
@@ -159,6 +159,7 @@ namespace BH.Engine.Dynamo
         // A quasi-fallback method - lines sometimes come out of Dynamo as objects of type Line, sometimes of type Curve.
         public static BHG.ICurve FromDesignScript(this ADG.Curve curve)
         {
+            // For some reason Dynamo wraps curves of other type into Curve, instead of using them as they are - Explode here is simply unwrapping the actual curves of more specific types.
             if (curve.GetType() == typeof(ADG.Curve))
             {
                 List<ADG.Curve> curves = curve.Explode().Cast<ADG.Curve>().ToList();
@@ -169,6 +170,7 @@ namespace BH.Engine.Dynamo
             }
             else
             {
+                // Fallback method for the missing converts, e.g. Helix.
                 BH.Engine.Reflection.Compute.RecordWarning(String.Format("Convert from DesignScript to BHoM is missing for curves of type {0}. The curve has been approximated with lines and arcs.", curve.GetType()));
                 return new BHG.PolyCurve { Curves = curve.ApproximateWithArcAndLineSegments().Select(x => x.IFromDesignScript()).ToList() };
             }

--- a/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
+++ b/Dynamo20/Dynamo_Engine/Convert/FromDesignScript.cs
@@ -216,7 +216,7 @@ namespace BH.Engine.Dynamo
                 return new BHG.Polyline { ControlPoints = controlPoints };
             }
             else
-                return Geometry.Create.PolyCurve(polyCurve.Curves().Select(x => x.IFromDesignScript()));
+                return Geometry.Create.PolyCurve(curves);
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #224

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FDynamo%5FToolkit%2FDynamo%5FToolkit%2DIssue224%2DGeometryConverts) - the test file is very basic but at least all basic converts (apart from solids) prove to _work_ in both directions (first the geometry gets converted to BHoM due to the method wrapped inside component and then back for the output. To preview the outputs of a component, right-click and _Preview_ from context menu. 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Existing geometry converts from BHoM to DesignScript were reviewed and bugfixed
- Missing geometry converts from BHoM to DesignScript were added
- Missing ellipse convert from DesignScript to BHoM was added
- Convert of `DesignScript.Curve` from DesignScript to BHoM was fixed not to cause stack overflow


### Additional comments
<!-- As required -->
As discussed, the changes will not make the things worse, therefore I am relaxed about merging the day before Beta. Happy to support the review process if needed and try to push it in today if possible.