### PR TITLE
Usage log now saving caller type name instead of caller name

### DIFF
--- a/Dynamo13/Dynamo_Engine/Compute/RunCaller.cs
+++ b/Dynamo13/Dynamo_Engine/Compute/RunCaller.cs
@@ -193,7 +193,7 @@ namespace BH.Engine.Dynamo
             // Log usage
             try
             {
-                UI.Compute.LogUsage("Dynamo", "2.0", Guid.Parse(callerId), caller?.Name, caller?.SelectedItem, events);
+                UI.Compute.LogUsage("Dynamo", "1.3", Guid.Parse(callerId), caller?.GetType().Name, caller?.SelectedItem, events);
             }
             catch { }
 

--- a/Dynamo20/Dynamo_Engine/Compute/RunCaller.cs
+++ b/Dynamo20/Dynamo_Engine/Compute/RunCaller.cs
@@ -193,7 +193,7 @@ namespace BH.Engine.Dynamo
             // Log usage
             try
             {
-                UI.Compute.LogUsage("Dynamo", "2.0", Guid.Parse(callerId), caller?.Name, caller?.SelectedItem, events);
+                UI.Compute.LogUsage("Dynamo", "2.0", Guid.Parse(callerId), caller?.GetType().Name, caller?.SelectedItem, events);
             }
             catch { }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #258

Same as for other UIs: Caller Type name should be saved instead of caller name in usage log.
