### PR TITLE
Get the global menu to work as soon as dynamo is open

### DIFF
--- a/Dynamo20/BHoM_ExtensionDefinition.xml
+++ b/Dynamo20/BHoM_ExtensionDefinition.xml
@@ -1,0 +1,4 @@
+<ExtensionDefinition>
+  <AssemblyPath>..\bin\Dynamo_UI.dll</AssemblyPath>
+  <TypeName>BH.UI.Dynamo.Global.Extension</TypeName>
+</ExtensionDefinition>

--- a/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
+++ b/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Components\oM\CreateData.cs" />
     <Compile Include="Components\oM\CreateType.cs" />
     <Compile Include="Components\oM\CreateObject.cs" />
+    <Compile Include="Global\Extention.cs" />
     <Compile Include="Global\GlobalSearch.cs" />
     <Compile Include="Templates\CallerValueList.cs" />
     <Compile Include="Templates\CallerComponent.cs" />
@@ -272,18 +273,22 @@
     <PostBuildEvent>xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\pkg.json"
+xcopy /Y /I ..\*_ExtensionDefinition.xml "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.0\packages\BHoM\extra"
 
 xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\pkg.json"
+xcopy /Y /I ..\*_ExtensionDefinition.xml "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\BHoM\extra"
 
 xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\bin"
 Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\pkg.json"
+xcopy /Y /I ..\*_ExtensionDefinition.xml "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Core\2.3\packages\BHoM\extra"
 
 xcopy /Y /E /I C:\ProgramData\BHoM\Assemblies\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
 xcopy /Y /E ..\Build\*.dll "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\bin"
-Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\pkg.json"</PostBuildEvent>
+Copy /Y ..\pkg.json "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\pkg.json"
+xcopy /Y /I ..\*_ExtensionDefinition.xml "C:\Users\$(Username)\AppData\Roaming\Dynamo\Dynamo Revit\2.3\packages\BHoM\extra"</PostBuildEvent>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Revit\1.3\DynamoSandbox.exe</StartProgram>
   </PropertyGroup>

--- a/Dynamo20/Dynamo_UI/Global/Extention.cs
+++ b/Dynamo20/Dynamo_UI/Global/Extention.cs
@@ -20,75 +20,67 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.UI.Base.Components;
+using BH.UI.Dynamo.Components;
+using BH.UI.Dynamo.Templates;
+using BH.UI.Base.Global;
+using BH.UI.Base;
+using Dynamo.Controls;
+using Dynamo.Graph.Nodes;
+using Dynamo.Models;
+using Dynamo.ViewModels;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using BH.oM.Data.Collections;
-using Dynamo.Wpf;
-using Dynamo.Controls;
-using BH.UI.Dynamo.Templates;
-using System.Windows.Controls;
 using System.Linq;
-using BH.Engine.Data;
-using BH.UI.Base;
-using Dynamo.Engine;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using static Dynamo.Models.DynamoModel;
+using Dynamo.Extensions;
 
-namespace BH.UI.Dynamo.Templates
+namespace BH.UI.Dynamo.Global
 {
-    public abstract class CallerView<T> : INodeViewCustomization<T> where T : CallerComponent
+    public class Extension : IExtension
     {
         /*******************************************/
-        /**** Constructors                      ****/
+        /**** Properties                        ****/
         /*******************************************/
 
-        public CallerView() {}
+        public string Name { get; } = "BHoM Extension";
+
+        public string UniqueId { get; } = Guid.NewGuid().ToString();
 
 
         /*******************************************/
-        /**** Interface Methods                 ****/
+        /**** IExtension Methods                ****/
         /*******************************************/
 
-        public virtual void CustomizeView(T component, NodeView nodeView)
+        public void Startup(StartupParams sp)
         {
-            m_Node = component;
-            m_View = nodeView;
-            m_DynamoEngine = nodeView.ViewModel.DynamoViewModel.Model.EngineController;
-            Caller caller = component.Caller;
+        }
 
-            if (caller != null)
+        /*******************************************/
+
+        public void Ready(ReadyParams sp)
+        {
+            Application.Current.Startup += (sender, e) =>
             {
-                caller.AddToMenu(nodeView.MainContextMenu);
-                caller.Modified += Caller_ItemSelected;
-            }
+                GlobalSearchMenu.Activate();
+            };
         }
 
         /*******************************************/
 
-        public void Dispose() { }
-
-
-        /*******************************************/
-        /**** Protected Methods                 ****/
-        /*******************************************/
-
-        protected virtual void Caller_ItemSelected(object sender, object e)
+        public void Shutdown()
         {
-            m_Node.RefreshComponent();
-
-            Caller caller = m_Node.Caller;
-
-            if (caller != null && m_View != null)
-                caller.AddToMenu(m_View.MainContextMenu);
         }
 
-
-        /*******************************************/
-        /**** Private Fields                    ****/
         /*******************************************/
 
-        protected CallerComponent m_Node = null;
-        protected NodeView m_View = null;
-        protected EngineController m_DynamoEngine = null;
+        public void Dispose()
+        {
+        }
 
         /*******************************************/
     }

--- a/Dynamo20/Dynamo_UI/Global/GlobalSearch.cs
+++ b/Dynamo20/Dynamo_UI/Global/GlobalSearch.cs
@@ -53,7 +53,18 @@ namespace BH.UI.Dynamo.Global
         {
             if (!m_Activated && Application.Current != null)
             {
-                Window window = Application.Current.Windows.OfType<Window>().SingleOrDefault(w => w.IsActive);
+                // Get the window
+                DynamoView window = Application.Current.Windows.OfType<DynamoView>().SingleOrDefault();
+                if (window == null)
+                    return;
+
+                // Get the Dynamo model
+                DynamoViewModel viewModel = window.DataContext as DynamoViewModel;
+                if (viewModel == null)
+                    return;
+                DynamoModel = viewModel.Model;
+
+                // Activate the global menu
                 GlobalSearch.Activate(window);
                 GlobalSearch.ItemSelected += GlobalSearch_ItemSelected;
                 m_Activated = true;

--- a/Dynamo20/Dynamo_UI/Templates/CallerComponent.cs
+++ b/Dynamo20/Dynamo_UI/Templates/CallerComponent.cs
@@ -100,13 +100,6 @@ namespace BH.UI.Dynamo.Templates
             Caller.Modified += (sender, e) => RefreshComponent();
         }
 
-        /*******************************************/
-
-        static CallerComponent()
-        {
-            GlobalSearchMenu.Activate();
-        }
-
 
         /*******************************************/
         /**** Public Methods                    ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #173 

Until now, we had to drop a component on the canvas for the Global menu to start working. This PR fixes that.

Note that global menu still doesn't work at all in 2020. Sadly this is a completely different problem and far from trivial (this is Autodesk after all) so will fix separately.


### Test files
Just open Dynamo and hit `Ctrl+Shift+B`. Easier test of your life 😉 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
I noticed that you don't need to drop a Revit component first anymore. Was it specific a a given version of Revit ? I couldn't find the issue talking about this.