### PR TITLE
Adding GetEvents component

### DIFF
--- a/Dynamo20/Dynamo_UI/Components/Engine/GetEvents.cs
+++ b/Dynamo20/Dynamo_UI/Components/Engine/GetEvents.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Dynamo.Objects;
+using BH.UI.Dynamo.Templates;
+using BH.UI.Base.Components;
+using BH.UI.Base;
+using Dynamo.Graph.Nodes;
+using ProtoCore.AST.AssociativeAST;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace BH.UI.Dynamo.Components
+{
+    [NodeName("GetEvents")]
+    [NodeCategory("BHoM.Engine")]
+    [NodeDescription("Get all events (errors, warnings, and notes) occuring on BHoM components.")]
+    [IsDesignScriptCompatible]
+    public class GetEventsComponent : CallerComponent
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public override Caller Caller { get; } = new GetEventsCaller();
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public GetEventsComponent() : base() { }
+
+        /*******************************************/
+
+        [JsonConstructor]
+        public GetEventsComponent(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+
+        /*******************************************/
+    }
+}
+

--- a/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
+++ b/Dynamo20/Dynamo_UI/Dynamo20_UI.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Components\Adapter\Execute.cs" />
     <Compile Include="Components\Adapter\Remove.cs" />
     <Compile Include="Components\Engine\Explode.cs" />
+    <Compile Include="Components\Engine\GetEvents.cs" />
     <Compile Include="Components\Engine\GetInfo.cs" />
     <Compile Include="Components\Engine\Query.cs" />
     <Compile Include="Components\Engine\Modify.cs" />

--- a/Dynamo20/Dynamo_UI/Global/GlobalSearch.cs
+++ b/Dynamo20/Dynamo_UI/Global/GlobalSearch.cs
@@ -117,6 +117,7 @@ namespace BH.UI.Dynamo.Global
             { typeof(ExplodeCaller),            typeof(ExplodeComponent) },
             { typeof(FromJsonCaller),           typeof(FromJsonComponent) },
             { typeof(GetInfoCaller),            typeof(GetInfoComponent) },
+            { typeof(GetEventsCaller),          typeof(GetEventsComponent) },
             { typeof(GetPropertyCaller),        typeof(GetPropertyComponent) },
             { typeof(ModifyCaller),             typeof(ModifyComponent) },
             { typeof(QueryCaller),              typeof(QueryComponent) },


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_UI/pull/331
   
### Issues addressed by this PR
See https://github.com/BHoM/BHoM_UI/pull/331


### Additional comments
If you found yourself in the situation where the component fails (silently) to create itself, make sure to manually clean the BHoM folders in `AppData\Roaming\Dynamo` for 2.3 (core and Revit). It seems that the installer is still copying the dlls there therefore creating a conflict with the dll in `ProgramData/BHoM`. 