### PR TITLE
Fix Dynamo crash on intitialisation of GlobalSearchMenu type

### DIFF
--- a/Dynamo20/Dynamo_UI/Global/GlobalSearch.cs
+++ b/Dynamo20/Dynamo_UI/Global/GlobalSearch.cs
@@ -75,6 +75,51 @@ namespace BH.UI.Dynamo.Global
 
 
         /*******************************************/
+        /**** Public Static Constructor         ****/
+        /*******************************************/
+
+        static GlobalSearchMenu()
+        {
+            try
+            {
+                m_CallerComponentDic = new Dictionary<Type, Type>
+                {
+                    { typeof(CreateAdapterCaller),      typeof(CreateAdapterComponent) },
+                    { typeof(CreateRequestCaller),        typeof(CreateRequestComponent) },
+                    { typeof(RemoveCaller),             typeof(RemoveComponent) },
+                    { typeof(ExecuteCaller),            typeof(ExecuteComponent) },
+                    { typeof(MoveCaller),               typeof(MoveComponent) },
+                    { typeof(PullCaller),               typeof(PullComponent) },
+                    { typeof(PushCaller),               typeof(PushComponent) },
+
+                    { typeof(ComputeCaller),            typeof(ComputeComponent) },
+                    { typeof(ConvertCaller),            typeof(ConvertComponent) },
+                    { typeof(ExplodeCaller),            typeof(ExplodeComponent) },
+                    { typeof(FromJsonCaller),           typeof(FromJsonComponent) },
+                    { typeof(GetInfoCaller),            typeof(GetInfoComponent) },
+                    { typeof(GetEventsCaller),          typeof(GetEventsComponent) },
+                    { typeof(GetPropertyCaller),        typeof(GetPropertyComponent) },
+                    { typeof(ModifyCaller),             typeof(ModifyComponent) },
+                    { typeof(QueryCaller),              typeof(QueryComponent) },
+                    { typeof(SetPropertyCaller),        typeof(SetPropertyComponent) },
+                    { typeof(ToJsonCaller),             typeof(ToJsonComponent) },
+
+                    { typeof(CreateCustomCaller),       typeof(CreateCustomComponent) },
+                    { typeof(CreateDataCaller),         typeof(CreateDataComponent) },
+                    { typeof(CreateDictionaryCaller),   typeof(CreateDictionaryComponent) },
+                    { typeof(CreateEnumCaller),         typeof(CreateEnumComponent) },
+                    { typeof(CreateObjectCaller),       typeof(CreateObjectComponent) },
+                    { typeof(CreateTypeCaller),         typeof(CreateTypeComponent) }
+                };
+            }
+            catch(Exception e)
+            {
+                Debug.WriteLine("Error on initialisation of the GlobalSearchMenu type: " + e.Message);
+            }
+        }
+
+
+        /*******************************************/
         /**** Private Methods                   ****/
         /*******************************************/
 
@@ -101,36 +146,7 @@ namespace BH.UI.Dynamo.Global
         /*******************************************/
 
         private static List<DynamoView> m_ActiveWindows = new List<DynamoView>();
-
-        private static Dictionary<Type, Type> m_CallerComponentDic = new Dictionary<Type, Type>
-        {
-            { typeof(CreateAdapterCaller),      typeof(CreateAdapterComponent) },
-            { typeof(CreateRequestCaller),        typeof(CreateRequestComponent) },
-            { typeof(RemoveCaller),             typeof(RemoveComponent) },
-            { typeof(ExecuteCaller),            typeof(ExecuteComponent) },
-            { typeof(MoveCaller),               typeof(MoveComponent) },
-            { typeof(PullCaller),               typeof(PullComponent) },
-            { typeof(PushCaller),               typeof(PushComponent) },
-
-            { typeof(ComputeCaller),            typeof(ComputeComponent) },
-            { typeof(ConvertCaller),            typeof(ConvertComponent) },
-            { typeof(ExplodeCaller),            typeof(ExplodeComponent) },
-            { typeof(FromJsonCaller),           typeof(FromJsonComponent) },
-            { typeof(GetInfoCaller),            typeof(GetInfoComponent) },
-            { typeof(GetEventsCaller),          typeof(GetEventsComponent) },
-            { typeof(GetPropertyCaller),        typeof(GetPropertyComponent) },
-            { typeof(ModifyCaller),             typeof(ModifyComponent) },
-            { typeof(QueryCaller),              typeof(QueryComponent) },
-            { typeof(SetPropertyCaller),        typeof(SetPropertyComponent) },
-            { typeof(ToJsonCaller),             typeof(ToJsonComponent) },
-
-            { typeof(CreateCustomCaller),       typeof(CreateCustomComponent) },
-            { typeof(CreateDataCaller),         typeof(CreateDataComponent) },
-            { typeof(CreateDictionaryCaller),   typeof(CreateDictionaryComponent) },
-            { typeof(CreateEnumCaller),         typeof(CreateEnumComponent) },
-            { typeof(CreateObjectCaller),       typeof(CreateObjectComponent) },
-            { typeof(CreateTypeCaller),         typeof(CreateTypeComponent) }
-        };
+        private static Dictionary<Type, Type> m_CallerComponentDic = new Dictionary<Type, Type>();
 
         /*******************************************/
     }

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,4 +1,5 @@
 BHoM/BHoM
 BHoM/BHoM_Engine
 BHoM/BHoM_Adapter
+BHoM/CSharp_Toolkit
 BHoM/BHoM_UI


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #280

This is the only thing that I can think of that would cause the crash mentioned in issue #280. Since I cannot reproduce the bug myself, this is only a guess. If that doesn't work, someone with the bug will have to run Dynamo with VS attached.

@mikolaj-nazarczuk 
